### PR TITLE
Fixing broken URL handling when used with Relation_Id

### DIFF
--- a/application/libraries/image_crud.php
+++ b/application/libraries/image_crud.php
@@ -357,8 +357,7 @@ class image_CRUD {
 
     protected function _get_delete_url($value)
     {
-    	$rsegments_array = $this->ci->uri->rsegment_array();
-    	return site_url($rsegments_array[1].'/'.$rsegments_array[2].'/delete_file/'.$value);
+	return $this->state->delete_file_url."/$value";
     }
 
     protected function _get_photos($relation_value = null)
@@ -410,82 +409,55 @@ class image_CRUD {
 	protected function getState()
 	{
 		$rsegments_array = $this->ci->uri->rsegment_array();
+		$controller = $rsegments_array[1].'/'.$rsegments_array[2];
+		$relv = (isset($rsegments_array[3]) && is_numeric($rsegments_array[3])) ? $rsegments_array[3] : "";
+		$controller .= ($relv) ? "/$relv" : "";
 
-		if(isset($rsegments_array[3]) && is_numeric($rsegments_array[3]))
-		{
-			$upload_url = site_url($rsegments_array[1].'/'.$rsegments_array[2].'/upload_file/'.$rsegments_array[3]);
-			$ajax_list_url  = site_url($rsegments_array[1].'/'.$rsegments_array[2].'/'.$rsegments_array[3].'/ajax_list');
-			$ordering_url  = site_url($rsegments_array[1].'/'.$rsegments_array[2].'/ordering');
-			$insert_title_url  = site_url($rsegments_array[1].'/'.$rsegments_array[2].'/insert_title');
-
-			$state = array( 'name' => 'list', 'upload_url' => $upload_url, 'relation_value' => $rsegments_array[3]);
-			$state['ajax'] = isset($rsegments_array[4]) && $rsegments_array[4] == 'ajax_list'  ? true : false;
-			$state['ajax_list_url'] = $ajax_list_url;
-			$state['ordering_url'] = $ordering_url;
-			$state['insert_title_url'] = $insert_title_url;
-
-
-			return (object)$state;
+		if ( $relv ) {  // Action is fourth when third is relation id, also fifth will be delete id
+			$action = (isset($rsegments_array[4]) && $rsegments_array[4]) ? $rsegments_array[4] : 'list';
+			$id = (isset($rsegments_array[5]) && is_numeric($rsegments_array[5])) ? $rsegments_array[5] : null;
+		} else {	// Third segment then, Id is in 4
+			$action = (isset($rsegments_array[3]) && $rsegments_array[3]) ? $rsegments_array[3] : 'list';
+			$id = (isset($rsegments_array[4]) && is_numeric($rsegments_array[4])) ? $rsegments_array[4] : null;
 		}
-		elseif( (empty($rsegments_array[3]) && empty($this->relation_field)) || (!empty($rsegments_array[3]) &&  $rsegments_array[3] == 'ajax_list'))
-		{
-			$upload_url = site_url($rsegments_array[1].'/'.$rsegments_array[2].'/upload_file');
-			$ajax_list_url  = site_url($rsegments_array[1].'/'.$rsegments_array[2].'/ajax_list');
-			$ordering_url  = site_url($rsegments_array[1].'/'.$rsegments_array[2].'/ordering');
-			$insert_title_url  = site_url($rsegments_array[1].'/'.$rsegments_array[2].'/insert_title');
 
-			$state = array( 'name' => 'list', 'upload_url' => $upload_url);
-			$state['ajax'] = isset($rsegments_array[3]) && $rsegments_array[3] == 'ajax_list'  ? true : false;
-			$state['ajax_list_url'] = $ajax_list_url;
-			$state['ordering_url'] = $ordering_url;
-			$state['insert_title_url'] = $insert_title_url;
+		$state = array( 'name' => 'list', 'ajax'=> false );
+		$state['upload_url']       = site_url("$controller/upload_file");
+		$state['ajax_list_url']    = site_url("$controller/ajax_list");
+		$state['ordering_url']     = site_url("$controller/ordering");
+		$state['insert_title_url'] = site_url("$controller/insert_title");
+		$state['delete_file_url']  = site_url("$controller/delete_file");
 
-			return (object)$state;
-		}
-		elseif(isset($rsegments_array[3]) && $rsegments_array[3] == 'upload_file')
-		{
-			#region Just rename my file
-				$new_file_name = '';
-				//$old_file_name = $this->_to_greeklish($_GET['qqfile']);
-				$old_file_name = $this->_convert_foreign_characters($_GET['qqfile']);
-				$max = strlen($old_file_name);
-				for($i=0; $i< $max;$i++)
-				{
-					$numMatches = preg_match('/^[A-Za-z0-9.-_]+$/', $old_file_name[$i], $matches);
-					if($numMatches >0)
-					{
-						$new_file_name .= strtolower($old_file_name[$i]);
-					}
-					else
-					{
-						$new_file_name .= '-';
-					}
+		if ($relv)
+			$state['relation_value'] = $relv;
+
+		if ( $action == 'ajax_list') {
+			$state['ajax'] = true;
+		} elseif ( $action == 'upload_file') {
+			$new_file_name = '';
+			$old_file_name = $this->_convert_foreign_characters($_GET['qqfile']);
+			$max = strlen($old_file_name);
+			for($i=0; $i< $max;$i++) {
+				$numMatches = preg_match('/^[A-Za-z0-9.-_]+$/', $old_file_name[$i], $matches);
+				if($numMatches >0) {
+					$new_file_name .= strtolower($old_file_name[$i]);
+				} else {
+					$new_file_name .= '-';
 				}
-				$file_name = substr( substr( uniqid(), 9,13).'-'.$new_file_name , 0, 100) ;
-			#endregion
-
-			$results = array( 'name' => 'upload_file', 'file_name' => $file_name);
-			if(isset($rsegments_array[4]) && is_numeric($rsegments_array[4]))
-			{
-				$results['relation_value'] = $rsegments_array[4];
 			}
-			return (object)$results;
+			$file_name = substr( substr( uniqid(), 9,13).'-'.$new_file_name , 0, 100) ;
+			$state['name'] = 'upload_file';
+			$state['file_name'] = $file_name;
+		} elseif( $action == 'delete_file') {
+			$state['name'] = 'delete_file';
+			$state['id'] = $id;	// Need id for deletion
+		} elseif( $action == 'ordering') {
+			$state['name'] = 'ordering';
+		} elseif( $action == 'insert_title') {
+			$state['name'] = 'insert_title';
 		}
-		elseif(isset($rsegments_array[3]) && isset($rsegments_array[4]) && $rsegments_array[3] == 'delete_file' && is_numeric($rsegments_array[4]))
-		{
-			$state = array( 'name' => 'delete_file', 'id' => $rsegments_array[4]);
-			return (object)$state;
-		}
-		elseif(isset($rsegments_array[3]) && $rsegments_array[3] == 'ordering')
-		{
-			$state = array( 'name' => 'ordering');
-			return (object)$state;
-		}
-		elseif(isset($rsegments_array[3]) && $rsegments_array[3] == 'insert_title')
-		{
-			$state = array( 'name' => 'insert_title');
-			return (object)$state;
-		}
+		$this->state = (object)$state;
+		return $this->state;
 	}
 
 	function render()
@@ -502,7 +474,8 @@ class image_CRUD {
 		{
 			switch ($state_info->name) {
 				case 'list':
-					$photos = isset($state_info->relation_value) ? $this->_get_photos($state_info->relation_value) : $this->_get_photos();
+					$photos = isset($state_info->relation_value) ? 
+						$this->_get_photos($state_info->relation_value) : $this->_get_photos();
 					$this->_library_view('list.php',array(
 						'upload_url' => $state_info->upload_url,
 						'insert_title_url' => $state_info->insert_title_url,


### PR DESCRIPTION
Rationalize URLs with Realtion_Value so that RelationId numeric is always in the same position. This behaviour is required when custom controller needs to pre-process that id e.g. for security.

See sample controller below: it would be called like   

/c/myeditor/6757

and 6757 needs to always remain there! so then crud urls shall look like

/c/myeditor/6757/upload_file
/c/myeditor/6757/delete_file/75
...

 function myeditor($id) {
   if ( $this->can_edit_this_id( $id ) ) {
      // do all the nice crud stuff
