### PR TITLE
Configurable thumb size

### DIFF
--- a/application/config/image_crud.php
+++ b/application/config/image_crud.php
@@ -3,5 +3,9 @@
 //For view all the languages go to the folder ./assets/image_crud/languages/
 $config['image_crud_default_language'] = 'english';
 
+// DEFAULT THUMB SIZES
+$config['image_crud_default_thumb_width'] = 120;
+$config['image_crud_default_thumb_height'] = 80;
+
 /* End of file image_crud.php */
 /* Location: ./application/config/image_crud.php */

--- a/application/libraries/image_crud.php
+++ b/application/libraries/image_crud.php
@@ -54,6 +54,11 @@ class image_CRUD {
 
 	function __construct() {
 		$this->ci = &get_instance();
+		
+		$this->ci->config->load('image_crud');
+		
+		$this->thumb_width  = intval($this->ci->config->item('image_crud_default_thumb_width'));
+		$this->thumb_height = intval($this->ci->config->item('image_crud_default_thumb_height'));
 	}
 
 	function set_table($table_name)
@@ -129,6 +134,15 @@ class image_CRUD {
 		$this->thumbnail_prefix = $prefix;
 
 		return $this;
+	}
+	
+	function set_thumbnail_size($width, $height)
+	{
+	  // SET THUMB SIZES; ELSE DEFAULT TO CONFIG SETTINGS
+  	$this->thumb_width  = intval($width) ?: $this->thumb_width;
+  	$this->thumb_height = intval($height) ?: $this->thumb_height;
+    
+    return $this;	
 	}
 
 	/**
@@ -408,7 +422,7 @@ class image_CRUD {
 	{
 		$this->image_moo
 			->load($image_path)
-			->resize_crop(90,60)
+      ->resize_crop($this->thumb_width,$this->thumb_height)
 			->save($thumbnail_path,true);
 	}
 


### PR DESCRIPTION
- **ADD:** `set_thumbnail_size()` takes 2 parameters: `$width` & `$height` _(int)_
  and updates `thumb_width` and `_height` properties
- **MOD:** `_create_thumbnail()` uses `thumb_width` and `_height` properties
- **MOD:** `__construct()` loads config to set default `thumb_width` and `_height`
- **ADD:** Config keys to set default thumb size
